### PR TITLE
Refactor to allow use on newer versions of MATLAB

### DIFF
--- a/+util/+garch/GarchInterface.m
+++ b/+util/+garch/GarchInterface.m
@@ -1,0 +1,28 @@
+classdef GarchInterface < handle
+  properties (Abstract)
+    fitResults
+  end
+
+  methods (Abstract)
+    fit(obj, data)
+    % Fit the GARCH model
+
+    [params, theta] = getStartingParams(obj, data)
+    % get the starting parameters for the SGJR model
+  end
+
+  methods
+    function [params, theta] = getStartingParameters(obj, data)
+      if (nargin < 2 && isempty(obj.fitResults))
+        error( ...
+          'SGJR:StartingParamters:NeedsEstimate', ...
+          'You have to estimate the GARCH model before getting the starting parameters' ...
+        );
+      elseif isempty(obj.fitResults)
+        obj.fit(data);
+      end
+
+      [params, theta] = obj.getStartingParams(data);
+    end
+  end
+end

--- a/+util/+garch/NewGarch.m
+++ b/+util/+garch/NewGarch.m
@@ -1,0 +1,24 @@
+classdef NewGarch < util.garch.GarchInterface
+  properties
+    fitResults
+  end
+
+  methods
+    function fit(obj, data)
+      obj.fitResults = gjr(1, 1).estimate(data, 'Display', 'off');
+    end
+
+    function [params, theta] = getStartingParams(obj, data)
+      params = [ ...
+        obj.fitResults.Constant / 100^2; ...
+        cell2mat(obj.fitResults.ARCH)'; ...
+        cell2mat(obj.fitResults.Leverage)'; ...
+        cell2mat(obj.fitResults.GARCH)' ...
+      ];
+
+      theta = sum(cell2mat(obj.fitResults.ARCH)) + ...
+              0.5 * sum(cell2mat(obj.fitResults.Leverage)) + ...
+              sum(cell2mat(obj.fitResults.GARCH));
+    end
+  end
+end

--- a/+util/+garch/OldSchoolGarch.m
+++ b/+util/+garch/OldSchoolGarch.m
@@ -1,0 +1,26 @@
+classdef OldSchoolGarch < util.garch.GarchInterface
+  properties
+    fitResults
+  end
+
+  methods
+    function fit(obj, data)
+      spec = garchset( ...
+        'Distribution' , 'Gaussian'  , 'P', 1, 'Q', 1, 'VarianceModel', 'GJR', 'Display', 'off' ...
+      );
+
+      [obj.fitResults, ~, ~, ~, ~] = garchfit(spec, data);
+    end
+
+    function [params, theta] = getStartingParams(obj, data)
+      params = [ ...
+        obj.fitResults.K / 100^2; ...
+        obj.fitResults.ARCH; ...
+        obj.fitResults.Leverage; ...
+        obj.fitResults.GARCH ...
+      ];
+
+      theta = obj.fitResults.ARCH + 0.5 * obj.fitResults.Leverage + obj.fitResults.GARCH;
+    end
+  end
+end

--- a/+util/+pool/MatlabPool.m
+++ b/+util/+pool/MatlabPool.m
@@ -1,0 +1,15 @@
+classdef MatlabPool < util.pool.PoolInterface
+  methods
+    function close(obj)
+      matlabpool close;
+    end
+
+    function TF = isOpen(obj)
+      TF = ~isempty(gcp);
+    end
+
+    function open(obj)
+      matlabpool open;
+    end
+  end
+end

--- a/+util/+pool/ParPool.m
+++ b/+util/+pool/ParPool.m
@@ -1,0 +1,24 @@
+classdef ParPool < util.pool.PoolInterface
+  properties
+    poolObj
+  end
+
+  methods
+    function close(obj)
+      try
+        delete(gcp('nocreate'));
+      catch ME
+      end
+
+      delete(obj.poolObj);
+    end
+
+    function TF = isOpen(obj)
+      TF = ~isempty(gcp('nocreate'));
+    end
+
+    function open(obj)
+      obj.poolObj = parpool;
+    end
+  end
+end

--- a/+util/+pool/PoolInterface.m
+++ b/+util/+pool/PoolInterface.m
@@ -1,0 +1,12 @@
+classdef PoolInterface < handle
+  methods (Abstract)
+    close(obj)
+    % Close a pool
+
+    TF = isOpen(obj)
+    % Determine if a pool is open
+
+    open(obj)
+    % Open a pool
+  end
+end

--- a/+util/Garch.m
+++ b/+util/Garch.m
@@ -1,0 +1,46 @@
+classdef Garch
+  properties
+    garchObj
+    originalWarnings
+  end
+
+  methods
+    function obj = Garch
+      obj.originalWarnings = warning ('off','econ:garchfit:FunctionToBeRemoved');
+      warning ('off','econ:garchset:FunctionToBeRemoved');
+      warning ('off','econ:garchinfer:FunctionToBeRemoved');
+      warning ('off','econ:garchpred:FunctionToBeRemoved');
+
+      if obj.hasOldGarch
+        obj.garchObj = util.garch.OldSchoolGarch();
+      else
+        obj.garchObj = util.garch.NewGarch();
+      end
+    end
+
+    function fit(obj, data)
+      obj.garchObj.fit(data);
+    end
+
+    function TF = hasOldGarch(obj)
+      try
+        garchspec();
+        TF= true;
+      catch ME
+        if strcmp(ME.message, 'Undefined function or variable ''garchspec''.')
+          TF = false;
+        else
+          rethrow(ME);
+        end
+      end
+    end
+
+    function [params, theta] = getStartingParameters(obj, data)
+      [params, theta] = obj.garchObj.getStartingParameters(data);
+    end
+
+    function delete(obj)
+      warning(obj.originalWarnings);
+    end
+  end
+end

--- a/+util/Pool.m
+++ b/+util/Pool.m
@@ -1,0 +1,41 @@
+classdef Pool
+  properties
+    poolObject
+  end
+
+  methods
+    function obj = Pool
+      if obj.hasMatlabPool
+        obj.poolObject = util.pool.MatlabPool();
+      else
+        obj.poolObject = util.pool.ParPool();
+      end
+    end
+
+    function TF = hasMatlabPool(obj)
+      try
+        matlabpool;
+        matlabpool close;
+        TF = true;
+      catch ME
+        if strcmp(ME.message, 'Undefined function or variable ''matlabpool''.')
+          TF = false;
+        else
+          rethrow(ME);
+        end
+      end
+    end
+
+    function close(obj)
+      obj.poolObject.close();
+    end
+
+    function TF = isOpen(obj)
+      TF = obj.poolObject.isOpen();
+    end
+
+    function open(obj)
+      obj.poolObject.open();
+    end
+  end
+end

--- a/sgjr.m
+++ b/sgjr.m
@@ -28,12 +28,6 @@ function result = sgjr( ...
   %    result            - An SGJRResult object
   %
   % SEE ALSO:  result/SGJRResult
-  originalWarningState = warning ('off','econ:garchfit:FunctionToBeRemoved');
-  warning ('off','econ:garchset:FunctionToBeRemoved');
-  warning ('off','econ:garchinfer:FunctionToBeRemoved');
-  warning ('off','econ:garchpred:FunctionToBeRemoved');
-
-  c1 = onCleanup(@() restoreWarningState(originalWarningState));
 
   % TODO - ask Emil the format of zero curve data
   options = processOptions(varargin{:});
@@ -93,10 +87,4 @@ function smoothedTau = createSmoothedTau(bvDebtComponents, debtMaturities)
 
   rawTau = sum(repmat(debtMaturities, T, 1) .* dWeights, 2);
   smoothedTau = util.exponentiallySmooth(rawTau, 0.01);
-end
-
-function restoreWarningState(originalWarningState)
-  if (~isempty(originalWarningState))
-    warning(originalWarningState);
-  end
 end


### PR DESCRIPTION
Refactor code to utilize the new Econometrics Toolbox GARCH interface, if the old interface is not available.  Also, refactor to use ParPool, if matlabpool is not available.