### PR TITLE
Fill parameters, if missing

### DIFF
--- a/+util/+garch/NewGarch.m
+++ b/+util/+garch/NewGarch.m
@@ -3,6 +3,16 @@ classdef NewGarch < util.garch.GarchInterface
     fitResults
   end
 
+  methods (Static)
+    function result = getParam(param)
+      if (isempty(param))
+        result = [0];
+      else
+        result = cell2mat(param)';
+      end
+    end
+  end
+
   methods
     function fit(obj, data)
       obj.fitResults = gjr(1, 1).estimate(data, 'Display', 'off');
@@ -11,9 +21,9 @@ classdef NewGarch < util.garch.GarchInterface
     function [params, theta] = getStartingParams(obj, data)
       params = [ ...
         obj.fitResults.Constant / 100^2; ...
-        cell2mat(obj.fitResults.ARCH)'; ...
-        cell2mat(obj.fitResults.Leverage)'; ...
-        cell2mat(obj.fitResults.GARCH)' ...
+        obj.getParam(obj.fitResults.ARCH); ...
+        obj.getParam(obj.fitResults.Leverage); ...
+        obj.getParam(obj.fitResults.GARCH) ...
       ];
 
       theta = sum(cell2mat(obj.fitResults.ARCH)) + ...


### PR DESCRIPTION
In newer versions of MATLAB, if you specify a (for example) gjr(1, 1)
model and while estimating it is determined that the coefficient is
zero, it will not place a value of zero into the result struct.
Instead, it will leave the placeholder empty.

This change inserts the zero back in where it belongs so that we have
proper starting values for the structural GARCH estimation.