### PR TITLE
Fix matlabpool call in util.Pool.hasMatlabPool

### DIFF
--- a/+util/Pool.m
+++ b/+util/Pool.m
@@ -14,8 +14,7 @@ classdef Pool
 
     function TF = hasMatlabPool(obj)
       try
-        matlabpool;
-        matlabpool close;
+        matlabpool('size');
         TF = true;
       catch ME
         if strcmp(ME.message, 'Undefined function or variable ''matlabpool''.')


### PR DESCRIPTION
Just calling matlabpool() will cause a 'Found interactive session' if
a matlabpool is alread open.  However, calling matlabpool('size') does
not throw an error.  Changing calls so we can effectively determine
how parallel processing is accomplished without crashing the system.